### PR TITLE
Adds Community List API Endpoint

### DIFF
--- a/models/Community.js
+++ b/models/Community.js
@@ -46,6 +46,10 @@ module.exports = (sequelize, DataTypes) => {
                 }
             }
         },
+        favourites: {
+            type: DataTypes.INTEGER,
+            default: 0
+        },
         description: DataTypes.TEXT,
         sidebar: DataTypes.TEXT,
         nsfw: DataTypes.BOOLEAN

--- a/models/Community.js
+++ b/models/Community.js
@@ -48,7 +48,7 @@ module.exports = (sequelize, DataTypes) => {
         },
         favourites: {
             type: DataTypes.INTEGER,
-            default: 0
+            defaultValue: 0
         },
         description: DataTypes.TEXT,
         sidebar: DataTypes.TEXT,

--- a/models/Favourite.js
+++ b/models/Favourite.js
@@ -11,6 +11,27 @@ module.exports = (sequelize, DataTypes) => {
     Favourite.associate = function(models) {
         models.Favourite.belongsTo(models.User);
         models.Favourite.belongsTo(models.Community);
+
+        // Hooks to update the Community table favourites amount
+        Favourite.afterCreate((favourite, options) => models.Community
+            .update({
+                favourites: sequelize.literal('favourites + 1')
+            }, {
+                where: {
+                    id: favourite.CommunityId
+                }
+            })
+        );
+
+        Favourite.afterDestroy((favourite, options) => models.Community
+            .update({
+                favourites: sequelize.literal('favourites - 1')
+            }, {
+                where: {
+                    id: favourite.CommunityId
+                }
+            })
+        );
     };
 
     return Favourite;

--- a/routes/api/communities/index.js
+++ b/routes/api/communities/index.js
@@ -29,18 +29,12 @@ router.post('/', auth.isAuthenticated, (req, res) => {
 router.get('/:name', async (req, res) => {
     const name = req.params.name;
 
-    const community = await models.Community.findAll({
+    const community = await models.Community.findOne({
         where: models.sequelize.where(models.sequelize.fn('lower', models.sequelize.col('name')), name.toLowerCase()),
-        attributes: {
-            include: [[models.sequelize.fn('COUNT', models.sequelize.col('Favourites.id')), 'favourites']]
-        },
         include: [{
             model: models.User,
             as: 'creator',
             attributes: ['username']
-        }, {
-            model: models.Favourite,
-            attributes: []
         }],
     });
 
@@ -95,7 +89,8 @@ router.delete('/:name/favourite', auth.isAuthenticated, async (req, res) => {
         where: {
             UserId: req.session.userId,
             CommunityId: community.id
-        }
+        },
+        individualHooks: true
     }).then(() => {
         res.json({message: 'Successfully unfavourited the community'});
     }).catch((err) => {

--- a/routes/api/communities/index.js
+++ b/routes/api/communities/index.js
@@ -24,6 +24,40 @@ router.post('/', auth.isAuthenticated, (req, res) => {
 });
 
 /**
+ * Gets lists of communities
+ */
+router.get('/', async (req, res) => {
+    const sort = (['top', 'new'].includes(req.query.sort) && req.query.sort) || 'top';
+    const count = (0 < parseInt(req.query.count) && parseInt(req.query.count) < 100) ? parseInt(req.query.count) : 10;
+    const offset = parseInt(req.query.offset) || 0;
+
+    let order;
+
+    if (sort === 'top') {
+        order = ['favourites', 'DESC']
+    }
+    else if (sort === 'new') {
+        order = ['createdAt', 'DESC'];
+    }
+
+    const totalCount = await models.Community.count();
+
+    const communities = await models.Community.findAll({
+        limit: count,
+        offset,
+        order: [order]
+    });
+
+    res.json({
+        communities,
+        totalCount,
+        offset,
+        size: communities.length,
+        sort
+    });
+});
+
+/**
  * Retrieves community details
  */
 router.get('/:name', async (req, res) => {


### PR DESCRIPTION
* Adds Community List API Endpoint that replies with a sorted and paginated list of communities
* Can sort by top (favourite amount) and new
* Adds computed `favourites` column to `Community` that is automatically updated using hooks when favourites are added/deleted; this greatly simplifies queries and is faster.

Closes #25 