### PR TITLE
Adds Community and User Searching Autocomplete Endpoint

### DIFF
--- a/routes/api/search/index.js
+++ b/routes/api/search/index.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const models = require('../models');
+const router = express.Router();
+const Op = models.Sequelize.Op;
+
+/**
+ * Returns search query results
+ */
+router.get('/:query', async (req, res) => {
+    const query = req.params.query;
+    const response = {};
+
+    // TODO: Use a real searching library
+
+    // Fetch users corresponding to the query
+    const users = await models.User.findAll({
+        attributes: ['username'],
+        where: {
+            username: {
+                like: `%${query}%`
+            }
+        }
+    });
+
+    response.users = users;
+
+    // Fetch communities corresponding to the query
+    const communities = await models.Community.findAll({
+        attributes: ['name', 'title', 'favourites', 'description', 'nsfw'],
+        where: {
+            [Op.or]: [
+                {name: {like: `%${query}%`}},
+                {title: {like: `%${query}%`}},
+                {description: {like: `%${query}%`}}
+            ]
+        },
+        order: [['favourites', 'DESC']]
+    });
+
+    response.communities = communities;
+
+    // TODO: Add Meme searching
+
+    res.json(response);
+});
+
+module.exports = router;

--- a/routes/api/search/index.js
+++ b/routes/api/search/index.js
@@ -4,10 +4,13 @@ const router = express.Router();
 const Op = models.Sequelize.Op;
 
 /**
- * Returns search query results
+ * Returns search query autocomplete results
  */
-router.get('/:query', async (req, res) => {
+router.get('/:query/autocomplete', async (req, res) => {
     const query = req.params.query;
+    let typeCount = parseInt(req.query.typeCount);
+    typeCount = (0 < typeCount && typeCount <= 10 && typeCount) || 4;
+
     const response = {};
 
     // TODO: Use a real searching library
@@ -19,14 +22,15 @@ router.get('/:query', async (req, res) => {
             username: {
                 like: `%${query}%`
             }
-        }
+        },
+        limit: typeCount
     });
 
     response.users = users;
 
     // Fetch communities corresponding to the query
     const communities = await models.Community.findAll({
-        attributes: ['name', 'title', 'favourites', 'description', 'nsfw'],
+        attributes: ['name', 'title', 'favourites', 'nsfw'],
         where: {
             [Op.or]: [
                 {name: {like: `%${query}%`}},
@@ -34,7 +38,8 @@ router.get('/:query', async (req, res) => {
                 {description: {like: `%${query}%`}}
             ]
         },
-        order: [['favourites', 'DESC']]
+        order: [['favourites', 'DESC']],
+        limit: typeCount
     });
 
     response.communities = communities;

--- a/routes/api/search/index.js
+++ b/routes/api/search/index.js
@@ -8,8 +8,8 @@ const Op = models.Sequelize.Op;
  */
 router.get('/:query/autocomplete', async (req, res) => {
     const query = req.params.query;
-    let typeCount = parseInt(req.query.typeCount);
-    typeCount = (0 < typeCount && typeCount <= 10 && typeCount) || 4;
+    let countPerType = parseInt(req.query.countPerType);
+    countPerType = (0 < countPerType && countPerType <= 10 && countPerType) || 4;
 
     const response = {};
 
@@ -23,7 +23,7 @@ router.get('/:query/autocomplete', async (req, res) => {
                 like: `%${query}%`
             }
         },
-        limit: typeCount
+        limit: countPerType
     });
 
     response.users = users;
@@ -39,7 +39,7 @@ router.get('/:query/autocomplete', async (req, res) => {
             ]
         },
         order: [['favourites', 'DESC']],
-        limit: typeCount
+        limit: countPerType
     });
 
     response.communities = communities;

--- a/routes/api/v1.js
+++ b/routes/api/v1.js
@@ -9,5 +9,6 @@ router.use('/auth', require('./auth'));
 router.use('/users', require('./users'));
 router.use('/communities', require('./communities'));
 router.use('/me', require('./me'));
+router.use('/search', require('./search'));
 
 module.exports = router;


### PR DESCRIPTION
`v1/search/:query/autocomplete`

Example: `v1/search/bitconnect/autocomplete`
returns the form of
```json
{
    "users": [],
    "communities": [
        {
            "name": "bcc2",
            "title": "Bitconnect...",
            "favourites": 1,
            "description": null,
            "nsfw": null
        },
        {
            "name": "bcCbvvbbnv2",
            "title": "Bitconnect...",
            "favourites": 0,
            "description": null,
            "nsfw": null
        },
        {
            "name": "bcbc2",
            "title": "Bitconnect...",
            "favourites": 0,
            "description": null,
            "nsfw": null
        }
    ]
}
```

Includes optional `typeCount` parameter that limits the amount of results returned for each type