### PR TITLE
Adds Endpoint for Fetching Community Templates and Fixes Sorting Retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Favourites the given community, returns an error if already favourited
 
 Deletes a community favourite if it is favourited
 
+### `GET /v1/communities/:community/templates?sort=top|new&offset=0&count=10`
+
+Retrieves list of templates that have been used in the given community sorted by the parameters
+
+`top` templates are sorted by the amount of memes using that template in the community
+
 ### `POST /v1/templates`
 
 Creates new template

--- a/routes/api/utils.js
+++ b/routes/api/utils.js
@@ -32,7 +32,8 @@ exports.getTemplates = async function(sort, count, offset, communityId) {
             'createdAt',
         ],
         limit: count,
-        offset
+        offset,
+        subQuery: false, // We want the limit to apply to the outer query
     };
 
     if (sort === 'new') {
@@ -53,8 +54,7 @@ exports.getTemplates = async function(sort, count, offset, communityId) {
                 attributes: ['username'],
             }],
             group: ['Template.id'],
-            order: [[models.sequelize.fn('COUNT', models.sequelize.col('Memes.id')), 'DESC']],
-            subQuery: false, // We want the limit to apply to the outer query
+            order: [[models.sequelize.fn('COUNT', models.sequelize.col('Memes.id')), 'DESC']]
         });
     }
     else {

--- a/routes/api/utils.js
+++ b/routes/api/utils.js
@@ -22,3 +22,71 @@ exports.getPrivateUserDetails = async function(username) {
 
     return user;
 };
+
+
+exports.getTemplates = async function(sort, count, offset, communityId) {
+    let options = {
+        limit: count,
+        offset
+    };
+
+    if (communityId) {
+        options = Object.assign(options, {
+            where: {
+                CommunityId: communityId
+            },
+        });
+    }
+
+    if (sort === 'new') {
+        options = Object.assign(options, {
+            attributes: {
+                exclude: [
+                    'updatedAt',
+                    'creatorId',
+                    'serialized'
+                ]
+            },
+            order: [['createdAt', 'DESC']],
+            include: [{
+                model: models.User,
+                as: 'creator',
+                attributes: ['username']
+            }],
+        });
+    }
+    else if (sort === 'top') {
+        options = Object.assign(options, {
+            attributes: {
+                include: [
+                    [models.sequelize.fn('COUNT', models.sequelize.col('Memes.id')), 'memeCount'],
+                ],
+                exclude: [
+                    'updatedAt',
+                    'creatorId',
+                    'serialized'
+                ]
+            },
+            include: [{
+                model: models.User,
+                as: 'creator',
+                attributes: ['username']
+            }, {
+                attributes: [],
+                model: models.Meme,
+            }],
+            group: ['Template.id'],
+            order: models.sequelize.literal('memeCount DESC'),
+        });
+    }
+    else {
+        throw new Error("Improper sort parameter given");
+    }
+
+    const result = await models.Template.findAndCountAll(options);
+
+    return {
+        totalCount: result.count,
+        templates: result.rows
+    };
+};

--- a/routes/api/utils.js
+++ b/routes/api/utils.js
@@ -31,6 +31,11 @@ exports.getTemplates = async function(sort, count, offset, communityId) {
             'previewLink',
             'createdAt',
         ],
+        include: [{
+            model: models.User,
+            as: 'creator',
+            attributes: ['username'],
+        }],
         limit: count,
         offset,
         subQuery: false, // We want the limit to apply to the outer query
@@ -38,21 +43,11 @@ exports.getTemplates = async function(sort, count, offset, communityId) {
 
     if (sort === 'new') {
         options = Object.assign(options, {
-            include: [{
-                model: models.User,
-                as: 'creator',
-                attributes: ['username']
-            }],
             order: [['createdAt', 'DESC']]
         });
     }
     else if (sort === 'top') {
         options = Object.assign(options, {
-            include: [{
-                model: models.User,
-                as: 'creator',
-                attributes: ['username'],
-            }],
             group: ['Template.id'],
             order: [[models.sequelize.fn('COUNT', models.sequelize.col('Memes.id')), 'DESC']]
         });


### PR DESCRIPTION
* `GET /v1/communities/:title/templates?sort=top|new&after=:memeid:&count=10` - Fetches templates used in the given community, top sorts by most used templates within the community by the amount of memes in the community that use it
*  Fixes SubQuery Handling for Sequelize when doing the COUNT within the query