### PR TITLE
Adds Access Control Allow Credentials to Server Response

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ app.use((req, res, next) => {
         res.header('Access-Control-Allow-Origin', origin);
         res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
         res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE');
+        res.header('Access-Control-Allow-Credentials', 'true');
         next();
     } else if (config.ensureOrigin) {
         res.status(400).json({error: 'Invalid request origin'});


### PR DESCRIPTION
* This should not pose a security risk since the server has a whitelist of origins

Some info on the header: https://stackoverflow.com/questions/24687313/what-exactly-does-the-access-control-allow-credentials-header-do

We check the origin header: https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Identifying_Source_Origin